### PR TITLE
BOSIGN-425677-Update PlanID Changes in cubeflakes insurance demo Site

### DIFF
--- a/Views/Home/About.cshtml
+++ b/Views/Home/About.cshtml
@@ -36,6 +36,6 @@
     </div>
     <div class="signup-wrapper">
         <span class="content highlight-content">This is the right time to create your <span class="highlight-big">Free</span> account!</span>
-        <a href="https://account.boldsign.com/signup?planId=315" id="btnSignUp" class="Submit-btn">Sign Up</a>
+        <a href="https://account.boldsign.com/signup?planId=1076" id="btnSignUp" class="Submit-btn">Sign Up</a>
     </div>
 </div>


### PR DESCRIPTION
### Summary
Updated the Plan ID used in the signup link on the BoldSign cubeflakes insurance demo site to align with the latest plan rollout.

### Changes Implemented
Replaced the previous Plan ID in the signup link with the newly provided one.

### Purpose of the Change
This update aligns with the recent Plan ID restructure across our platform. It ensures consistency between the cubeflakes insurance demo site and the pricing plans displayed on the main site, providing a seamless user experience.

### Rollout Date
The new Plan ID structure was deployed on the BoldSign pricing page on February 7, 2025.

### Reference Link
[Website Post](https://teams.microsoft.com/l/message/19:66d80e3d73d14b6a903f23ab5299b05a@thread.tacv2/1738768284193?tenantId=77f1fe12-b049-4919-8c50-9fb41e5bb63b&groupId=2c0a7c0d-870e-4e5d-bf2c-c937f7391cd7&parentMessageId=1738768284193&teamName=BoldSign&channelName=Website&createdTime=1738768284193)
[Task 428919](https://dev.azure.com/Syncfusion-Bold/BoldSign/_workitems/edit/428919): Plan Id Changes on Cubeflakes Insurance Demo Site):